### PR TITLE
♻️ Refactor :  모든 Icon color, size 통일

### DIFF
--- a/src/components/data-display/Avatar/Avatar.stories.tsx
+++ b/src/components/data-display/Avatar/Avatar.stories.tsx
@@ -108,7 +108,7 @@ export const IconAvatars: Story = {
     return (
       <>
         <Avatar {...args}>
-          <PersonIcon />
+          <PersonIcon color="white" />
         </Avatar>
         <Avatar
           style={{
@@ -151,22 +151,22 @@ export const Sizes: Story = {
         </div>
         <div style={{ display: 'flex', gap: '10px' }}>
           <Avatar size="xs" {...args}>
-            <PersonIcon />
+            <PersonIcon color="white" />
           </Avatar>
           <Avatar size="sm" {...args}>
-            <PersonIcon />
+            <PersonIcon color="white" />
           </Avatar>
           <Avatar {...args}>
-            <PersonIcon />
+            <PersonIcon color="white" />
           </Avatar>
           <Avatar size="lg" {...args}>
-            <PersonIcon />
+            <PersonIcon color="white" />
           </Avatar>
           <Avatar size="xl" {...args}>
-            <PersonIcon />
+            <PersonIcon color="white" />
           </Avatar>
           <Avatar size={200} {...args}>
-            <PersonIcon size={100} />
+            <PersonIcon color="white" size={100} />
           </Avatar>
         </div>
       </div>

--- a/src/components/data-display/Avatar/Avatar.tsx
+++ b/src/components/data-display/Avatar/Avatar.tsx
@@ -16,7 +16,7 @@ export interface AvatarProps extends React.HtmlHTMLAttributes<HTMLSpanElement> {
   style?: StyleType;
 }
 
-const DefaultAvatarIcon = () => <PersonIcon />;
+const DefaultAvatarIcon = () => <PersonIcon color="white" />;
 
 const Avatar = (props: AvatarProps) => {
   const {

--- a/src/components/data-display/Badge/Badge.stories.tsx
+++ b/src/components/data-display/Badge/Badge.stories.tsx
@@ -136,7 +136,7 @@ export const BasicBadge: Story = {
           <Square />
         </Badge>
         <Badge
-          badgeContent={<MailIcon size={20} />}
+          badgeContent={<MailIcon color="primary" size={20} />}
           {...args}
           color="rgba(0,0,0,0)"
         >

--- a/src/components/icons/Icons.mdx
+++ b/src/components/icons/Icons.mdx
@@ -1,5 +1,6 @@
 import { Meta, Title, IconGallery, IconItem, Canvas } from '@storybook/blocks';
 import { PersonIcon } from './PersonIcon';
+import { MailIcon } from './MailIcon';
 
 <Meta />
 
@@ -9,5 +10,8 @@ import { PersonIcon } from './PersonIcon';
 <IconGallery>
   <IconItem name="person">
     <PersonIcon color="black" />
+  </IconItem>
+  <IconItem name="mail">
+    <MailIcon color="black" />
   </IconItem>
 </IconGallery>

--- a/src/components/icons/MailIcon/MailIcon.tsx
+++ b/src/components/icons/MailIcon/MailIcon.tsx
@@ -6,24 +6,24 @@ interface MailIconProps {
   color?: ColorType;
 }
 
-const MailIcon = ({ size = 32, color = 'primary' }: MailIconProps) => {
+const MailIcon = ({ size = 24, color = 'black' }: MailIconProps) => {
   return (
     <svg
       width={size}
       height={size}
-      viewBox="0 0 32 32"
+      viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <g clipPath="url(#clip0_86_145)">
+      <g clip-path="url(#clip0_86_145)">
         <path
-          d="M26.6667 5.33331H5.33334C3.86667 5.33331 2.68001 6.53331 2.68001 7.99998L2.66667 24C2.66667 25.4666 3.86667 26.6666 5.33334 26.6666H26.6667C28.1333 26.6666 29.3333 25.4666 29.3333 24V7.99998C29.3333 6.53331 28.1333 5.33331 26.6667 5.33331ZM26.6667 10.6666L16 17.3333L5.33334 10.6666V7.99998L16 14.6666L26.6667 7.99998V10.6666Z"
+          d="M20 4H4C2.9 4 2.01 4.9 2.01 6L2 18C2 19.1 2.9 20 4 20H20C21.1 20 22 19.1 22 18V6C22 4.9 21.1 4 20 4ZM20 8L12 13L4 8V6L12 11L20 6V8Z"
           fill={editColor(color)}
         />
       </g>
       <defs>
         <clipPath id="clip0_86_145">
-          <rect width="32" height="32" fill="white" />
+          <rect width="24" height="24" fill="white" />
         </clipPath>
       </defs>
     </svg>

--- a/src/components/icons/PersonIcon/PersonIcon.tsx
+++ b/src/components/icons/PersonIcon/PersonIcon.tsx
@@ -6,19 +6,26 @@ interface PersonIconProps {
   color?: ColorType;
 }
 
-const PersonIcon = ({ size = 44, color = 'white' }: PersonIconProps) => {
+const PersonIcon = ({ size = 24, color = 'black' }: PersonIconProps) => {
   return (
     <svg
       width={size}
       height={size}
-      viewBox="0 0 44 44"
+      viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <path
-        d="M22 22C28.0775 22 33 17.0775 33 11C33 4.9225 28.0775 0 22 0C15.9225 0 11 4.9225 11 11C11 17.0775 15.9225 22 22 22ZM22 27.5C14.6575 27.5 0 31.185 0 38.5V44H44V38.5C44 31.185 29.3425 27.5 22 27.5Z"
-        fill={editColor(color)}
-      />
+      <g clip-path="url(#clip0_86_149)">
+        <path
+          d="M12 12C14.21 12 16 10.21 16 8C16 5.79 14.21 4 12 4C9.79 4 8 5.79 8 8C8 10.21 9.79 12 12 12ZM12 14C9.33 14 4 15.34 4 18V20H20V18C20 15.34 14.67 14 12 14Z"
+          fill={editColor(color)}
+        />
+      </g>
+      <defs>
+        <clipPath id="clip0_86_149">
+          <rect width="24" height="24" fill="white" />
+        </clipPath>
+      </defs>
     </svg>
   );
 };


### PR DESCRIPTION
## 작업 내용 \*

- 모든 Icon 컴포넌트 color='black', size='24'로 통일

## 참고 자료
