### PR TITLE
♻️ Refactor :  useStyle을 사용해 `Stack`의 responsive prop 처리

### DIFF
--- a/src/components/layout/Stack/Stack.scss
+++ b/src/components/layout/Stack/Stack.scss
@@ -1,13 +1,3 @@
-@mixin flexDirection {
-  @each $direction in row, row-reverse, column, column-reverse {
-    &.#{$direction} {
-      flex-direction: $direction;
-    }
-  }
-}
-
 .JinniStack {
   display: flex;
-
-  @include flexDirection;
 }

--- a/src/components/layout/Stack/Stack.stories.tsx
+++ b/src/components/layout/Stack/Stack.stories.tsx
@@ -171,7 +171,15 @@ export const Customization: Story = {
     <Section>
       <Stack
         direction="row"
-        style={{ justifyContent: 'space-between' }}
+        style={{
+          justifyContent: {
+            xs: 'flex-start',
+            sm: 'flex-end',
+            md: 'center',
+            lg: 'space-between',
+            xl: 'stretch'
+          }
+        }}
         {...args}
       >
         <Box order={1} />

--- a/src/components/layout/Stack/Stack.tsx
+++ b/src/components/layout/Stack/Stack.tsx
@@ -1,10 +1,9 @@
 import './Stack.scss';
 import cn from 'classnames';
-import useBreakpoint from '@/hooks/useBreakpoint';
 import { Responsive } from '@/types/breakpoint';
 import { StyleType } from '@/types/style';
-import { insertDivider, isResponsive } from './Stack.utils';
-import { editColorStyle } from '@/utils/editColorStyle';
+import { insertDivider } from './Stack.utils';
+import useStyle from '@/hooks/useStyle';
 
 export type DirectionType = 'row' | 'row-reverse' | 'column' | 'column-reverse';
 
@@ -26,19 +25,14 @@ const Stack = (props: StackProps) => {
     className,
     style
   } = props;
-  const breakpoint = useBreakpoint();
-  const newDirection = isResponsive<DirectionType>(direction)
-    ? direction[breakpoint]
-    : direction;
-  const newSpacing = isResponsive<number>(spacing)
-    ? spacing[breakpoint]
-    : spacing;
+  const newStyle = useStyle({
+    flexDirection: direction,
+    gap: spacing,
+    ...style
+  });
 
   return (
-    <div
-      className={cn('JinniStack', newDirection, className)}
-      style={{ gap: newSpacing, ...editColorStyle(style) }}
-    >
+    <div className={cn('JinniStack', className)} style={newStyle}>
       {divider ? insertDivider(children, divider) : children}
     </div>
   );

--- a/src/components/layout/Stack/Stack.utils.ts
+++ b/src/components/layout/Stack/Stack.utils.ts
@@ -1,5 +1,3 @@
-import { Responsive } from '@/types/breakpoint';
-
 export const insertDivider = (
   children: React.ReactNode,
   divider: React.ReactNode
@@ -10,11 +8,4 @@ export const insertDivider = (
   return children
     .flatMap((child, idx) => (isLastChild(idx) ? [child] : [child, divider]))
     .map((child, idx) => ({ ...child, key: idx }));
-};
-
-export const isResponsive = <T>(element: unknown): element is Responsive<T> => {
-  if (!element || typeof element !== 'object') return false;
-
-  const breakpoints = ['xs', 'sm', 'md', 'lg', 'xl'];
-  return Object.keys(element).every((key) => breakpoints.includes(key));
 };

--- a/src/hooks/useStyle.ts
+++ b/src/hooks/useStyle.ts
@@ -1,0 +1,23 @@
+import { StyleType } from '@/types/style';
+import { isResponsive } from '@/utils/isResponsive';
+import useBreakpoint from '@/hooks/useBreakpoint';
+
+type EditedStyleType = React.CSSProperties & {
+  [key: string]: React.CSSProperties[keyof React.CSSProperties];
+};
+
+const useStyle = (style: StyleType): EditedStyleType => {
+  const breakpoint = useBreakpoint();
+  const editedStyle: EditedStyleType = {};
+
+  Object.entries(style).forEach(([key, value]) => {
+    if (isResponsive(value)) {
+      return (editedStyle[key] = value[breakpoint]);
+    }
+    return (editedStyle[key] = value);
+  });
+
+  return editedStyle;
+};
+
+export default useStyle;

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -1,7 +1,16 @@
 import { ColorType } from '@/types/color';
 import { CSS_COLOR_PROPERTIES } from '@/constants/css-color-properties';
+import { Responsive } from '@/types/breakpoint';
 
 type CSSColorProperties = (typeof CSS_COLOR_PROPERTIES)[number];
+type ResponsiveCSSProperties = {
+  [K in keyof React.CSSProperties]?:
+    | React.CSSProperties[K]
+    | Responsive<React.CSSProperties[K]>;
+};
+type ResponsiveCSSColorProperties = Partial<
+  Record<CSSColorProperties, ColorType | Responsive<ColorType>>
+>;
 
-export type StyleType = Omit<React.CSSProperties, CSSColorProperties> &
-  Partial<Record<CSSColorProperties, ColorType>>;
+export type StyleType = Omit<ResponsiveCSSProperties, CSSColorProperties> &
+  ResponsiveCSSColorProperties;

--- a/src/utils/isResponsive.ts
+++ b/src/utils/isResponsive.ts
@@ -1,0 +1,8 @@
+import { Responsive } from '@/types/breakpoint';
+
+export const isResponsive = <T>(element: unknown): element is Responsive<T> => {
+  if (!element || typeof element !== 'object') return false;
+
+  const breakpoints = ['xs', 'sm', 'md', 'lg', 'xl'];
+  return Object.keys(element).every((key) => breakpoints.includes(key));
+};


### PR DESCRIPTION
## 작업 내용 \*

- `useStyle` 훅 생성
  - responsive style 처리

```ts
type StyleType = Omit<ResponsiveCSSProperties, CSSColorProperties> & ResponsiveCSSColorProperties;
type useStyle = (style: StyleType) => React.CSSProperties;
```

- useStyle을 사용해 `Stack`의 responsive prop(spacing, direction) 처리

## 참고 자료
