### PR TITLE
✨ Feat : useStyle에 typography 처리 추가

### DIFF
--- a/src/components/_share/JinniProvider/JinniProvider.tsx
+++ b/src/components/_share/JinniProvider/JinniProvider.tsx
@@ -1,8 +1,10 @@
 import JinniContext, { JinniValueType } from '@/contexts/JinniContext';
 import { getJinniBreakPointValue } from '@/utils/breakpoint';
 import { getJinniColorValue } from '@/utils/color';
+import { getJinniTypographyValue } from '@/utils/typography';
 import { BREAKPOINTS } from '@/constants/breakpoint';
 import { COLOR_THEME, COLOR_PALETTE } from '@/constants/color';
+import { TYPOGRAPHY } from '@/constants/typography';
 
 interface JinniProviderProps {
   children: React.ReactNode;
@@ -23,7 +25,11 @@ const JinniProvider = ({ children }: JinniProviderProps) => {
         (cul, color) => ({ ...cul, [color]: getJinniColorValue(color) }),
         {}
       )
-    }
+    },
+    typography: TYPOGRAPHY.reduce(
+      (cul, typo) => ({ ...cul, [typo]: getJinniTypographyValue(typo) }),
+      {}
+    )
   } as JinniValueType;
 
   return (

--- a/src/constants/typography.ts
+++ b/src/constants/typography.ts
@@ -1,0 +1,17 @@
+export const TYPOGRAPHY = [
+  'display-large',
+  'display-medium',
+  'display-small',
+  'headline-large',
+  'headline-medium',
+  'headline-small',
+  'title-large',
+  'title-medium',
+  'title-small',
+  'label-large',
+  'label-medium',
+  'label-small',
+  'body-large',
+  'body-medium',
+  'body-small'
+] as const;

--- a/src/contexts/JinniContext.ts
+++ b/src/contexts/JinniContext.ts
@@ -1,6 +1,7 @@
 import { createContext } from 'react';
 import { BreakpointType } from '@/types/breakpoint';
 import { JinniColorTheme, JinniColorPalette } from '@/types/color';
+import { TypographyType, TypographySpec } from '@/types/typography';
 
 export interface JinniValueType {
   breakpoints: Record<BreakpointType, number>;
@@ -8,6 +9,7 @@ export interface JinniValueType {
     theme: Record<JinniColorTheme, string>;
     palette: Record<JinniColorPalette, string>;
   };
+  typography: Record<TypographyType, TypographySpec>;
 }
 
 const JinniContext = createContext<JinniValueType | null>(null);

--- a/src/hooks/useStyle.ts
+++ b/src/hooks/useStyle.ts
@@ -4,7 +4,9 @@ import useBreakpoint from '@/hooks/useBreakpoint';
 import useJinni from '@/hooks/useJinni';
 import { BREAKPOINTS } from '@/constants/breakpoint';
 import { COLOR_THEME, COLOR_PALETTE } from '@/constants/color';
+import { TYPOGRAPHY } from '@/constants/typography';
 import { Responsive, BreakpointType } from '@/types/breakpoint';
+import { TypographyType } from '@/types/typography';
 
 type DefaultStyleType = React.CSSProperties & {
   [key: string]: React.CSSProperties[keyof React.CSSProperties];
@@ -22,6 +24,9 @@ const isThemeColor = (
 const isPaletteColor = (
   value: StyleType[keyof StyleType]
 ): value is JinniColorPalette => COLOR_PALETTE.some((color) => color === value);
+const isTypography = (
+  value: StyleType[keyof StyleType]
+): value is TypographyType => TYPOGRAPHY.some((typo) => typo === value);
 
 const editResponsive = <T>(
   value: Responsive<T>,
@@ -39,7 +44,8 @@ const useStyle = (
   style: StyleType | undefined
 ): DefaultStyleType | undefined => {
   const {
-    color: { theme, palette }
+    color: { theme, palette },
+    typography
   } = useJinni();
   const breakpoint = useBreakpoint();
 
@@ -58,6 +64,11 @@ const useStyle = (
     }
     if (isPaletteColor(editedValue)) {
       editedValue = palette[editedValue];
+    }
+    if (key === 'typography' && isTypography(editedValue)) {
+      const typographyStyle = typography[editedValue];
+      Object.assign(editedStyle, typographyStyle);
+      return;
     }
     editedStyle[key] = editedValue;
   });

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '@/styles/variables' as var;
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&display=swap');
 
 $typo-types: 'display-large', 'display-medium', 'display-small',

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -2,90 +2,88 @@
 @use '@/styles/variables' as var;
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&display=swap');
 
-$typo-font-size: (
-  'display-large': 57px,
-  'display-medium': 45px,
-  'display-small': 36px,
-  'headline-large': 32px,
-  'headline-medium': 28px,
-  'headline-small': 24px,
-  'title-large': 22px,
-  'title-medium': 16px,
-  'title-small': 14px,
-  'label-large': 14px,
-  'label-medium': 12px,
-  'label-small': 11px,
-  'body-large': 16px,
-  'body-medium': 14px,
-  'body-small': 12px
-);
-
-$typo-line-height: (
-  'display-large': 64px,
-  'display-medium': 52px,
-  'display-small': 44px,
-  'headline-large': 40px,
-  'headline-medium': 36px,
-  'headline-small': 32px,
-  'title-large': 28px,
-  'title-medium': 24px,
-  'title-small': 20px,
-  'label-large': 20px,
-  'label-medium': 16px,
-  'label-small': 16px,
-  'body-large': 24px,
-  'body-medium': 20px,
-  'body-small': 16px
-);
-
-$typo-letter-spacing: (
-  'display-large': -0.25px,
-  'display-medium': 0px,
-  'display-small': 0px,
-  'headline-large': 0px,
-  'headline-medium': 0px,
-  'headline-small': 0px,
-  'title-large': 0px,
-  'title-medium': 0.15px,
-  'title-small': 0.1px,
-  'label-large': 0.1px,
-  'label-medium': 0.5px,
-  'label-small': 0.5px,
-  'body-large': 0.5px,
-  'body-medium': 0.25px,
-  'body-small': 0.4px
-);
-
-$typo-font-weight: (
-  'display-large': var.$font-weight-regular,
-  'display-medium': var.$font-weight-regular,
-  'display-small': var.$font-weight-regular,
-  'headline-large': var.$font-weight-regular,
-  'headline-medium': var.$font-weight-regular,
-  'headline-small': var.$font-weight-regular,
-  'title-large': var.$font-weight-regular,
-  'title-medium': var.$font-weight-medium,
-  'title-small': var.$font-weight-medium,
-  'label-large': var.$font-weight-medium,
-  'label-medium': var.$font-weight-medium,
-  'label-small': var.$font-weight-medium,
-  'body-large': var.$font-weight-regular,
-  'body-medium': var.$font-weight-regular,
-  'body-small': var.$font-weight-regular
-);
-
 $typo-types: 'display-large', 'display-medium', 'display-small',
   'headline-large', 'headline-medium', 'headline-small', 'title-large',
   'title-medium', 'title-small', 'label-large', 'label-medium', 'label-small',
   'body-large', 'body-medium', 'body-small';
 
+:root {
+  // typo-font-size
+  --jinni-typo-font-size-display-large: 57px;
+  --jinni-typo-font-size-display-medium: 45px;
+  --jinni-typo-font-size-display-small: 36px;
+  --jinni-typo-font-size-headline-large: 32px;
+  --jinni-typo-font-size-headline-medium: 28px;
+  --jinni-typo-font-size-headline-small: 24px;
+  --jinni-typo-font-size-title-large: 22px;
+  --jinni-typo-font-size-title-medium: 16px;
+  --jinni-typo-font-size-title-small: 14px;
+  --jinni-typo-font-size-label-large: 14px;
+  --jinni-typo-font-size-label-medium: 12px;
+  --jinni-typo-font-size-label-small: 11px;
+  --jinni-typo-font-size-body-large: 16px;
+  --jinni-typo-font-size-body-medium: 14px;
+  --jinni-typo-font-size-body-small: 12px;
+
+  // typo-line-height
+  --jinni-typo-line-height-display-large: 64px;
+  --jinni-typo-line-height-display-medium: 52px;
+  --jinni-typo-line-height-display-small: 44px;
+  --jinni-typo-line-height-headline-large: 40px;
+  --jinni-typo-line-height-headline-medium: 36px;
+  --jinni-typo-line-height-headline-small: 32px;
+  --jinni-typo-line-height-title-large: 28px;
+  --jinni-typo-line-height-title-medium: 24px;
+  --jinni-typo-line-height-title-small: 20px;
+  --jinni-typo-line-height-label-large: 20px;
+  --jinni-typo-line-height-label-medium: 16px;
+  --jinni-typo-line-height-label-small: 16px;
+  --jinni-typo-line-height-body-large: 24px;
+  --jinni-typo-line-height-body-medium: 20px;
+  --jinni-typo-line-height-body-small: 16px;
+
+  // typo-letter-spacing
+  --jinni-typo-letter-spacing-display-large: -0.25px;
+  --jinni-typo-letter-spacing-display-medium: 0px;
+  --jinni-typo-letter-spacing-display-small: 0px;
+  --jinni-typo-letter-spacing-headline-large: 0px;
+  --jinni-typo-letter-spacing-headline-medium: 0px;
+  --jinni-typo-letter-spacing-headline-small: 0px;
+  --jinni-typo-letter-spacing-title-large: 0px;
+  --jinni-typo-letter-spacing-title-medium: 0.15px;
+  --jinni-typo-letter-spacing-title-small: 0.1px;
+  --jinni-typo-letter-spacing-label-large: 0.1px;
+  --jinni-typo-letter-spacing-label-medium: 0.5px;
+  --jinni-typo-letter-spacing-label-small: 0.5px;
+  --jinni-typo-letter-spacing-body-large: 0.5px;
+  --jinni-typo-letter-spacing-body-medium: 0.25px;
+  --jinni-typo-letter-spacing-body-small: 0.4px;
+
+  // typo-font-weight
+  --jinni-typo-font-weight-display-large: 400;
+  --jinni-typo-font-weight-display-medium: 400;
+  --jinni-typo-font-weight-display-small: 400;
+  --jinni-typo-font-weight-headline-large: 400;
+  --jinni-typo-font-weight-headline-medium: 400;
+  --jinni-typo-font-weight-headline-small: 400;
+  --jinni-typo-font-weight-title-large: 400;
+  --jinni-typo-font-weight-title-medium: 500;
+  --jinni-typo-font-weight-title-small: 500;
+  --jinni-typo-font-weight-label-large: 500;
+  --jinni-typo-font-weight-label-medium: 500;
+  --jinni-typo-font-weight-label-small: 500;
+  --jinni-typo-font-weight-body-large: 400;
+  --jinni-typo-font-weight-body-medium: 400;
+  --jinni-typo-font-weight-body-small: 400;
+}
+
 @mixin typography($type) {
   font-family: 'Noto Sans KR', serif;
   font-style: normal;
-  font-size: map.get($typo-font-size, $type);
-  line-height: map.get($typo-line-height, $type);
-  letter-spacing: map.get($typo-letter-spacing, $type);
-  font-weight: map.get($typo-font-weight, $type);
+  font-size: var(--jinni-typo-font-size-#{$type});
+  line-height: var(--jinni-typo-line-height-#{$type});
+  letter-spacing: var(--jinni-typo-letter-spacing-#{$type});
+  font-weight: var(--jinni-typo-font-weight-#{$type});
 }
 
 * {

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -1,11 +1,14 @@
 import { ColorType } from '@/types/color';
 import { CSS_COLOR_PROPERTIES } from '@/constants/color';
 import { Responsive } from '@/types/breakpoint';
+import { TypographyType } from '@/types/typography';
 
 type CSSColorProperties = (typeof CSS_COLOR_PROPERTIES)[number];
 
 type BaseCSSProperties = Omit<React.CSSProperties, CSSColorProperties> &
-  Partial<Record<CSSColorProperties, ColorType>>;
+  Partial<Record<CSSColorProperties, ColorType>> & {
+    typography?: TypographyType;
+  };
 type ResponsiveCSSProperties = {
   [K in keyof BaseCSSProperties]?:
     | BaseCSSProperties[K]

--- a/src/types/typography.ts
+++ b/src/types/typography.ts
@@ -1,0 +1,8 @@
+import { TYPOGRAPHY } from '@/constants/typography';
+
+export type TypographyType = (typeof TYPOGRAPHY)[number];
+
+export type TypographySpec = Record<
+  'fontSize' | 'lineHeight' | 'letterSpacing' | 'fontWeight',
+  string
+>;

--- a/src/utils/typography.ts
+++ b/src/utils/typography.ts
@@ -1,0 +1,37 @@
+import { TypographyType, TypographySpec } from '@/types/typography';
+
+export const getJinniTypographyValue = (
+  typography: TypographyType
+): TypographySpec => {
+  const rootEl = document.querySelector(':root');
+  if (!rootEl) throw Error('root element를 가져오지 못함');
+
+  const rootStyles = window.getComputedStyle(rootEl);
+  const fontSize = rootStyles.getPropertyValue(
+    `--jinni-typo-font-size-${typography}`
+  );
+  const lineHeight = rootStyles.getPropertyValue(
+    `--jinni-typo-line-height-${typography}`
+  );
+  const letterSpacing = rootStyles.getPropertyValue(
+    `--jinni-typo-letter-spacing-${typography}`
+  );
+  const fontWeight = rootStyles.getPropertyValue(
+    `--jinni-typo-font-weight-${typography}`
+  );
+
+  if (!fontSize) throw Error(`'${typography}'의 font-size는 존재하지 않습니다`);
+  if (!lineHeight)
+    throw Error(`'${typography}'의 line-height는 존재하지 않습니다`);
+  if (!letterSpacing)
+    throw Error(`'${typography}'의 letter-spacing는 존재하지 않습니다`);
+  if (!fontWeight)
+    throw Error(`'${typography}'의 font-weight는 존재하지 않습니다`);
+
+  return {
+    fontSize,
+    lineHeight,
+    letterSpacing,
+    fontWeight
+  };
+};


### PR DESCRIPTION
## 작업 내용 \*

- `typography.scss`에서 map 대신 root 요소에 typo 변수 저장 => `var()` 함수를 통해 접근 가능
- `JinniContext`에 typography 추가
- `StyleType`, `useStyle`에 typography 처리 추가
- Jinni UI의 모든 컴포넌트는 `StyleType`의 style prop을 가짐
  - 따라서, style prop을 통해 typography를 지정해줄 수 있음 

```ts
<Component style={{ typography: 'display-large' }} />
```

## 참고 자료
