### PR TITLE
♻️ Refactor :  `Tooltip`의 children(anchor)이 single element인 경우, anchor props 삽입

### DIFF
--- a/src/components/data-display/Tooltip/Tooltip.mdx
+++ b/src/components/data-display/Tooltip/Tooltip.mdx
@@ -18,6 +18,9 @@ import { Tooltip } from '@/components/data-display/Tooltip';
 ### Basic Tooltip
 
 - `children`: anchor 요소
+
+  - 주의) anchor가 Component인 경우, 반드시 ref prop을 받을 수 있어야 함
+
 - `content`: tooltip 콘텐츠
 
 <Canvas of={TooltipStories.BasicTooltip} />

--- a/src/components/data-display/Tooltip/Tooltip.scss
+++ b/src/components/data-display/Tooltip/Tooltip.scss
@@ -88,7 +88,7 @@
 }
 
 .JinniTooltipAnchor {
-  display: inline-block;
+  display: inline-flex;
 }
 
 .JinniTooltipContainer {

--- a/src/components/data-display/Tooltip/Tooltip.tsx
+++ b/src/components/data-display/Tooltip/Tooltip.tsx
@@ -1,7 +1,7 @@
 import './Tooltip.scss';
 import cn from 'classnames';
 import { createPortal } from 'react-dom';
-import { useState, useRef, useMemo } from 'react';
+import { useState, useRef, useMemo, isValidElement, cloneElement } from 'react';
 import useStyle from '@/hooks/useStyle';
 import { AsType, DefaultComponentProps } from '@/types/default-component-props';
 import usePopperPosition from '@/hooks/usePopperPosition';
@@ -83,20 +83,24 @@ const Tooltip = <T extends AsType = 'span'>(props: TooltipProps<T>) => {
     onOpen,
     onClose
   });
+  const tooltipAnchorProps = {
+    ref: anchorRef,
+    className: 'JinniTooltipAnchor',
+    onMouseEnter: handleMouseEnter,
+    onMouseLeave: handleMouseLeave,
+    onClick: handleAnchorClick,
+    onFocus: handleFocus,
+    onBlur: handleBlur
+  };
+  const isSingleElement = isValidElement(children);
 
   return (
     <>
-      <span
-        ref={anchorRef}
-        className="JinniTooltipAnchor"
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        onClick={handleAnchorClick}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-      >
-        {children}
-      </span>
+      {isSingleElement ? (
+        cloneElement(children, tooltipAnchorProps)
+      ) : (
+        <span {...tooltipAnchorProps}>{children}</span>
+      )}
       {isOpen &&
         createPortal(
           <span


### PR DESCRIPTION
## 작업 내용 \*

### 변경 사항

#### 기존
- `Tooltip`의 children(anchor)을 타입 상관없이 항상 anchor props를 가진 span 태그로 감쌈

#### 변경
- `Tooltip`의 children(anchor)이 single element인 경우, anchor props 삽입
- `Tooltip`의 children(anchor)이 single element가 아닌 경우(string, number, array of elements 등), anchor props를 가진 span 태그로 감쌈

### 변경 이유

`Tooltip`의 children(anchor)을 span 태그로 감싸면, children의 크기가 span 크기에 제한되는 이슈가 있음.
예를 들어, `Tooltip`의 children(anchor)이 `<Button />`인 경우, Button에 fullWidth prop을 추가해도 span에 가로막혀 반영되지 않음. 따라서, 최소한 `Tooltip`의 children(anchor)이 single element이면 span 태그로 감싸지 않고 해당 요소에 anchor props를 삽입하는 방식으로 수정함.

## 참고 자료
