### PR TITLE
♻️ Refactor :  Popper 컴포넌트들(Tooltip, Popover, Modal 등) 코드 스타일 통일

### DIFF
--- a/src/components/data-display/Popover/Popover.mdx
+++ b/src/components/data-display/Popover/Popover.mdx
@@ -49,7 +49,7 @@ import { Popover } from '@/components/data-display/Popover';
 
 ### Elevation
 
-- `BoxProps`: Box 컴포넌트에 적용되는 props
+- `PopoverContentProps`: PopoverContent(=Box)에 적용되는 props
   - elevation(default=5), round(default=4px), padding 등 변경 가능
 
 <Canvas of={PopoverStories.Elevation} />

--- a/src/components/data-display/Popover/Popover.stories.tsx
+++ b/src/components/data-display/Popover/Popover.stories.tsx
@@ -40,10 +40,11 @@ const meta: Meta<typeof Popover> = {
         defaultValue: { summary: 'anchorEl' }
       }
     },
-    BoxProps: {
-      description: 'Box 컴포넌트에 적용되는 props',
+    PopoverContentProps: {
+      description: 'PopoverContent(=Box)에 적용되는 props',
       table: {
-        type: { summary: 'BoxProps' }
+        type: { summary: 'BoxProps' },
+        defaultValue: { summary: '{ elevation: 5, round: 4 }' }
       }
     },
     children: {
@@ -307,7 +308,11 @@ export const Elevation: Story = {
   render: (args) => {
     return (
       <PopoverAnchorElTemplate
-        BoxProps={{ elevation: 10, round: 'sm', style: { padding: '8px' } }}
+        PopoverContentProps={{
+          elevation: 10,
+          round: 'sm',
+          style: { padding: '8px' }
+        }}
         {...args}
       />
     );

--- a/src/components/data-display/Popover/Popover.tsx
+++ b/src/components/data-display/Popover/Popover.tsx
@@ -19,7 +19,7 @@ export type PopoverProps<T extends AsType = 'div'> = DefaultComponentProps<T> &
     children: React.ReactNode;
     open: boolean;
     onClose?: (event: MouseEvent | KeyboardEvent, reason: CloseReason) => void;
-    BoxProps?: BoxProps;
+    PopoverContentProps?: BoxProps;
   };
 
 const DEFAULT_ANCHOR_ORIGIN = {
@@ -36,7 +36,7 @@ const Popover = <T extends AsType = 'div'>(props: PopoverProps<T>) => {
     children,
     open,
     onClose,
-    BoxProps,
+    PopoverContentProps,
     anchorReference = 'anchorEl',
     anchorEl,
     anchorOrigin = DEFAULT_ANCHOR_ORIGIN,
@@ -76,7 +76,13 @@ const Popover = <T extends AsType = 'div'>(props: PopoverProps<T>) => {
         style={newStyle}
         {...rest}
       >
-        <Box elevation={5} round={4} style={{ padding: '16px' }} {...BoxProps}>
+        <Box
+          className="JinniPopoverContent"
+          elevation={5}
+          round={4}
+          style={{ padding: '16px' }}
+          {...PopoverContentProps}
+        >
           {children}
         </Box>
       </Component>

--- a/src/components/data-display/Tooltip/Tooltip.mdx
+++ b/src/components/data-display/Tooltip/Tooltip.mdx
@@ -67,7 +67,7 @@ import { Tooltip } from '@/components/data-display/Tooltip';
 
 ### Customization
 
-- `style` prop을 통해 background-color, color, box-shadow, max-width 등 커스텀 가능
+- `TooltipContentProps`를 통해 background-color, color, box-shadow, max-width 등 커스텀 가능
 
 <Canvas of={TooltipStories.Customization} />
 

--- a/src/components/data-display/Tooltip/Tooltip.scss
+++ b/src/components/data-display/Tooltip/Tooltip.scss
@@ -91,12 +91,12 @@
   display: inline-flex;
 }
 
-.JinniTooltipContainer {
+.JinniTooltip {
   display: inline-flex;
   position: fixed;
   z-index: var.$z-index-tooltip;
 
-  .JinniTooltip {
+  .JinniTooltipContent {
     position: relative;
     padding: 4px 8px;
     border-radius: 4px;
@@ -108,7 +108,7 @@
     user-select: none;
     @include offset;
 
-    .JinniTooltipArrow {
+    .JinniTooltipContentArrow {
       content: '';
       position: absolute;
       display: inline-block;

--- a/src/components/data-display/Tooltip/Tooltip.stories.tsx
+++ b/src/components/data-display/Tooltip/Tooltip.stories.tsx
@@ -48,6 +48,14 @@ const meta: Meta<typeof Tooltip> = {
         },
         defaultValue: { summary: `[hover, click, focus]` }
       }
+    },
+    TooltipContentProps: {
+      description: 'TooltipContent 컴포넌트의 props',
+      table: {
+        type: {
+          summary: `TooltipContentProps`
+        }
+      }
     }
   }
 };
@@ -348,12 +356,14 @@ export const Customization: Story = {
       <Stack direction="row" spacing={20}>
         <Tooltip
           content="Tooltip Contents"
-          style={{
-            backgroundColor: 'white',
-            color: 'black',
-            boxShadow: '5',
-            fontSize: '15px',
-            elevation: 5
+          TooltipContentProps={{
+            style: {
+              backgroundColor: 'white',
+              color: 'black',
+              boxShadow: '5',
+              fontSize: '15px',
+              elevation: 5
+            }
           }}
           {...args}
         >
@@ -361,7 +371,7 @@ export const Customization: Story = {
         </Tooltip>
         <Tooltip
           content="Long Text Long Text Long Text Long Text Long Text Long Text Long Text Long Text Long Text Long Text Long Text"
-          style={{ maxWidth: '300px' }}
+          TooltipContentProps={{ style: { maxWidth: '300px' } }}
           {...args}
         >
           <Button variant="outlined">Open Tooltip</Button>

--- a/src/components/data-display/Tooltip/Tooltip.tsx
+++ b/src/components/data-display/Tooltip/Tooltip.tsx
@@ -7,6 +7,7 @@ import { AsType, DefaultComponentProps } from '@/types/default-component-props';
 import usePopperPosition from '@/hooks/usePopperPosition';
 import { getAnchorOrigin, getPopperOrigin } from './Tooltip.utils';
 import { useHandleTriggers } from './Tooltip.hooks';
+import TooltipContent, { TooltipContentProps } from './TooltipContent';
 
 export type PlacementType =
   | 'top-start'
@@ -37,6 +38,7 @@ export type TooltipProps<T extends AsType = 'span'> = Omit<
   open?: boolean;
   onOpen?: (event: React.SyntheticEvent | Event) => void;
   onClose?: (event: React.SyntheticEvent | Event) => void;
+  TooltipContentProps?: TooltipContentProps;
 };
 
 const Tooltip = <T extends AsType = 'span'>(props: TooltipProps<T>) => {
@@ -50,6 +52,7 @@ const Tooltip = <T extends AsType = 'span'>(props: TooltipProps<T>) => {
     open: controlledOpen,
     onOpen,
     onClose,
+    TooltipContentProps,
     className,
     style,
     as: Component = 'span',
@@ -67,7 +70,11 @@ const Tooltip = <T extends AsType = 'span'>(props: TooltipProps<T>) => {
     popperOrigin,
     open: isOpen
   });
-  const newStyle = useStyle({ '--offset': `${offset}px`, ...style });
+  const newStyle = useStyle({
+    ...popperPosition,
+    '--offset': `${offset}px`,
+    ...style
+  });
   const {
     handleMouseEnter,
     handleMouseLeave,
@@ -103,22 +110,22 @@ const Tooltip = <T extends AsType = 'span'>(props: TooltipProps<T>) => {
       )}
       {isOpen &&
         createPortal(
-          <span
+          <Component
             ref={popperRef}
-            className={cn('JinniTooltipContainer')}
+            className={cn('JinniTooltip', className)}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
-            style={popperPosition}
+            style={newStyle}
+            {...rest}
           >
-            <Component
-              className={cn('JinniTooltip', placement, className)}
-              style={newStyle}
-              {...rest}
+            <TooltipContent
+              placement={placement}
+              arrow={arrow}
+              {...TooltipContentProps}
             >
               {content}
-              {arrow && <span className={cn('JinniTooltipArrow', placement)} />}
-            </Component>
-          </span>,
+            </TooltipContent>
+          </Component>,
           document.body
         )}
     </>

--- a/src/components/data-display/Tooltip/TooltipContent.tsx
+++ b/src/components/data-display/Tooltip/TooltipContent.tsx
@@ -1,0 +1,39 @@
+import cn from 'classnames';
+import useStyle from '@/hooks/useStyle';
+import { AsType, DefaultComponentProps } from '@/types/default-component-props';
+import { PlacementType } from './Tooltip';
+
+export type TooltipContentProps<T extends AsType = 'div'> =
+  DefaultComponentProps<T> & {
+    placement?: PlacementType;
+    children?: React.ReactNode;
+    arrow?: boolean;
+  };
+
+const TooltipContent = <T extends AsType = 'div'>(
+  props: TooltipContentProps<T>
+) => {
+  const {
+    placement,
+    children,
+    arrow,
+    className,
+    style,
+    as: Component = 'div',
+    ...rest
+  } = props;
+  const newStyle = useStyle(style);
+
+  return (
+    <Component
+      className={cn('JinniTooltipContent', placement, className)}
+      style={newStyle}
+      {...rest}
+    >
+      {children}
+      {arrow && <span className={cn('JinniTooltipContentArrow', placement)} />}
+    </Component>
+  );
+};
+
+export default TooltipContent;

--- a/src/components/feedback/Modal/Modal.stories.tsx
+++ b/src/components/feedback/Modal/Modal.stories.tsx
@@ -12,7 +12,15 @@ const meta: Meta<typeof Modal> = {
         'Modal 내 ModalContent 컴포넌트에 담겨질 요소 (ModalHeader, ModalBody, ModalFooter 등)'
     },
     ModalContentProps: {
-      description: 'Modal 내 ModalContent(=Box) 컴포넌트의 props'
+      description: 'Modal 내 ModalContent(=Box) 컴포넌트의 props',
+      table: {
+        type: {
+          summary: `BoxProps`
+        },
+        defaultValue: {
+          summary: `{ elevation: 15, round: isFullSize ? 0 : 4 }`
+        }
+      }
     },
     onClose: {
       description:


### PR DESCRIPTION
## 작업 내용 \*

- `Tooltip` 컴포넌트에서 TooltipContent 컴포넌트 분리
- `Popover`: BoxProps -> PopoverContentProps로 props명 변경
- `Modal`: storybook에서 ModalContentProps 설명 추가

## 참고 자료
