### PR TITLE
🐛 Fix : ripple effect 시 우측 하단에 깜빡이는 이슈 해결

### DIFF
--- a/src/hooks/useRipple/ripple.scss
+++ b/src/hooks/useRipple/ripple.scss
@@ -14,7 +14,7 @@
     position: absolute;
     border-radius: 50%;
     pointer-events: none;
-    animation: ripple 0.5s ease-in;
+    animation: ripple var(--duration-time) ease-in forwards;
     background-image: var(--ripple-overlay);
   }
 }

--- a/src/hooks/useRipple/useRipple.tsx
+++ b/src/hooks/useRipple/useRipple.tsx
@@ -10,6 +10,8 @@ export interface UseRippleProps {
   disableRipple?: boolean;
 }
 
+const DURATION_TIME = 500; // ms
+
 const useRipple = (props: UseRippleProps) => {
   const { theme } = useJinni();
   const {
@@ -74,9 +76,10 @@ const useRipple = (props: UseRippleProps) => {
       ripple.className = `JinniRipple ${rippleColor}`;
 
       rippleContainerEl.appendChild(ripple);
-      setTimeout(() => {
-        ripple.remove();
-      }, 500);
+      const timeoutId = setTimeout(() => {
+        rippleContainerEl.removeChild(ripple);
+        clearTimeout(timeoutId);
+      }, DURATION_TIME);
     };
 
     const handleKeyDown = (e: KeyboardEvent) =>
@@ -95,7 +98,10 @@ const useRipple = (props: UseRippleProps) => {
       <div
         ref={rippleContainerRef}
         className="JinniRippleContainer"
-        style={{ '--ripple-overlay': rippleOverlay }}
+        style={{
+          '--ripple-overlay': rippleOverlay,
+          '--duration-time': `${DURATION_TIME}ms`
+        }}
       ></div>
     ),
     [rippleOverlay]


### PR DESCRIPTION
## 작업 내용 \*

#### 이슈

- `RippleContainer`에서 ripple이 제거될 때, 클릭한 곳의 우측 하단에서 아주 짧은 시간 동안 scale이 적용되지 않은 ripple이 나타났다가 사라지는 현상이 있음

#### 원인
- `setTimeout`과 CSS 애니메이션 타이밍 불일치 때문임
- 여러 번 빠르게 클릭하는 경우, `setTimeout(fn, 500)`이 정확히 500ms 후에 실행되지 않고 지연됨
- CSS 애니메이션은 이미 끝났는데 ripple 제거가 아직 실행되지 않고 찰나에 브라우저가 리플로우/리페인트를 수행하면, 
애니메이션이 없는 초기 상태(scale(0), opacity: 1)로 ripple이 잠깐 렌더링 됨

#### 해결
- ripple 요소에 `animation-fill-mode: forwards` 스타일을 추가해서 
애니메이션 종료 후 마지막 keyframe 상태(opacity: 0)를 유지하도록 함
- 이로 인해, ripple 제거가 지연되어도 애니메이션이 끝난 ripple은 화면에 보이지 않음

## 참고 자료
