### PR TITLE
✨ Feat : InputBase의 padding 조정

### DIFF
--- a/src/components/Autocomplete/Autocomplete.scss
+++ b/src/components/Autocomplete/Autocomplete.scss
@@ -44,22 +44,21 @@
   @include animate-arrow-button;
   @include clear-button-style-by-size;
 
-  &:not(.disabled):hover {
-    cursor: pointer;
-  }
-
   .JinniInputBaseContent {
     position: relative;
     display: inline-flex;
     gap: 5px;
     align-items: center;
+    padding-right: 5px;
+    box-sizing: border-box;
+    min-width: 0;
 
     .JinniAutocompleteContent {
       flex: 1;
       display: inline-flex;
+      align-items: center;
       flex-wrap: wrap;
-      gap: 5px;
-      width: 100%;
+      min-width: 0;
 
       input.JinniAutocompleteInput {
         flex: 1;
@@ -69,9 +68,12 @@
 
       .JinniChip {
         display: inline-flex;
+        margin: 3px 0px 3px 5px;
         max-width: 100%;
         box-sizing: border-box;
         .JinniChipLabel {
+          flex: 1;
+          min-width: 0;
           overflow: hidden;
           white-space: nowrap;
           text-overflow: ellipsis;

--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -997,7 +997,12 @@ const LimitTagsTemplate = () => {
                 {label}
               </Chip>
             ))}
-            {restCount > 0 && <Text noMargin>{`+${restCount}`}</Text>}
+            {restCount > 0 && (
+              <Text
+                noMargin
+                style={{ marginLeft: '5px' }}
+              >{`+${restCount}`}</Text>
+            )}
           </>
         );
       }}
@@ -1734,7 +1739,7 @@ export const LimitTags: Story = {
                 color="gray-600"
                 endAdornment={
                   <ButtonBase
-                    onClick={(e: MouseEvent) => onDelete?.(e, value)}
+                    onClick={(e: React.MouseEvent) => onDelete?.(e, value)}
                     disableOverlay
                     disableRipple
                     style={{ width: '100%', height: '100%' }}
@@ -1750,7 +1755,12 @@ export const LimitTags: Story = {
                 {label}
               </Chip>
             ))}
-            {restCount > 0 && <Text noMargin>{\`+\${restCount}\`}</Text>}
+            {restCount > 0 && (
+              <Text
+                noMargin
+                style={{ marginLeft: '5px' }}
+              >{\`+\${restCount}\`}</Text>
+            )}
           </>
         );
       }}

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -259,6 +259,7 @@ const Autocomplete = <Multiple extends boolean = false>(
         disableFocusEffect={disableFocusEffect}
         fullWidth={fullWidth}
         focused={focused || isOpen}
+        noPadding
         style={style}
       >
         <Box className="JinniAutocompleteContent">
@@ -273,7 +274,7 @@ const Autocomplete = <Multiple extends boolean = false>(
           <input
             role="combobox"
             ref={inputElRef}
-            className="JinniAutocompleteInput"
+            className={cn('JinniAutocompleteInput', 'JinniInputBasePadding')}
             type="text"
             value={autocompleteInputValue}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -74,8 +74,10 @@ const Input = (props: InputProps) => {
       disableHoverEffect={disableHoverEffect}
       disableFocusEffect={disableFocusEffect}
       fullWidth={fullWidth}
+      noPadding
     >
       <input
+        className="JinniInputBasePadding"
         type={type}
         value={inputValue}
         onChange={handleChange}

--- a/src/components/InputBase/InputBase.scss
+++ b/src/components/InputBase/InputBase.scss
@@ -53,7 +53,13 @@
   &.sm {
     min-height: 29px;
     .JinniInputBaseContent {
-      padding: 3px 12px;
+      &:not(:has(input, textarea)) {
+        padding: 3px 12px;
+      }
+      input,
+      textarea {
+        padding: 3px 12px;
+      }
       font-size: 14px;
     }
     .JinniInputBaseAdornment {
@@ -63,7 +69,13 @@
   &.md {
     min-height: 36px;
     .JinniInputBaseContent {
-      padding: 5px 14px;
+      &:not(:has(input, textarea)) {
+        padding: 5px 14px;
+      }
+      input,
+      textarea {
+        padding: 5px 14px;
+      }
       font-size: 16px;
     }
     .JinniInputBaseAdornment {
@@ -73,7 +85,13 @@
   &.lg {
     min-height: 43px;
     .JinniInputBaseContent {
-      padding: 7px 16px;
+      &:not(:has(input, textarea)) {
+        padding: 7px 16px;
+      }
+      input,
+      textarea {
+        padding: 7px 16px;
+      }
       font-size: 18px;
     }
     .JinniInputBaseAdornment {
@@ -114,7 +132,6 @@
     input,
     textarea {
       display: inline-block;
-      padding: 0;
       width: 100%;
       min-height: 100%;
       border: none;

--- a/src/components/InputBase/InputBase.scss
+++ b/src/components/InputBase/InputBase.scss
@@ -53,14 +53,10 @@
   &.sm {
     min-height: 29px;
     .JinniInputBaseContent {
-      &:not(:has(input, textarea)) {
-        padding: 3px 12px;
-      }
-      input,
-      textarea {
-        padding: 3px 12px;
-      }
       font-size: 14px;
+    }
+    .JinniInputBasePadding {
+      padding: 3px 12px;
     }
     .JinniInputBaseAdornment {
       padding: 3px 6px;
@@ -69,14 +65,10 @@
   &.md {
     min-height: 36px;
     .JinniInputBaseContent {
-      &:not(:has(input, textarea)) {
-        padding: 5px 14px;
-      }
-      input,
-      textarea {
-        padding: 5px 14px;
-      }
       font-size: 16px;
+    }
+    .JinniInputBasePadding {
+      padding: 5px 14px;
     }
     .JinniInputBaseAdornment {
       padding: 5px 7px;
@@ -85,14 +77,10 @@
   &.lg {
     min-height: 43px;
     .JinniInputBaseContent {
-      &:not(:has(input, textarea)) {
-        padding: 7px 16px;
-      }
-      input,
-      textarea {
-        padding: 7px 16px;
-      }
       font-size: 18px;
+    }
+    .JinniInputBasePadding {
+      padding: 7px 16px;
     }
     .JinniInputBaseAdornment {
       padding: 7px 8px;

--- a/src/components/InputBase/InputBase.tsx
+++ b/src/components/InputBase/InputBase.tsx
@@ -20,6 +20,7 @@ export type RootInputBaseProps = {
   disableFocusEffect?: boolean;
   fullWidth?: boolean;
   focused?: boolean;
+  noPadding?: boolean;
 };
 
 export type InputBaseProps<T extends AsType = 'div'> = Omit<
@@ -45,6 +46,7 @@ const InputBase = <T extends AsType = 'div'>({
     disableFocusEffect = disabled,
     fullWidth,
     focused,
+    noPadding,
     className,
     style,
     as,
@@ -79,7 +81,13 @@ const InputBase = <T extends AsType = 'div'>({
       {startAdornment && (
         <span className="JinniInputBaseAdornment start">{startAdornment}</span>
       )}
-      <div className="JinniInputBaseContent">{children}</div>
+      <div
+        className={cn('JinniInputBaseContent', {
+          JinniInputBasePadding: !noPadding
+        })}
+      >
+        {children}
+      </div>
       {endAdornment && (
         <span className="JinniInputBaseAdornment end">{endAdornment}</span>
       )}

--- a/src/components/NumberInput/NumberInput.tsx
+++ b/src/components/NumberInput/NumberInput.tsx
@@ -113,8 +113,10 @@ const NumberInput = ({ ref, ...props }: NumberInputProps) => {
         disableHoverEffect={disableHoverEffect}
         disableFocusEffect={disableFocusEffect}
         fullWidth={fullWidth}
+        noPadding
       >
         <input
+          className="JinniInputBasePadding"
           ref={inputElRef}
           type="text"
           inputMode="numeric"

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -74,10 +74,11 @@ const TextArea = (props: TextAreaProps) => {
       disableHoverEffect={disableHoverEffect}
       disableFocusEffect={disableFocusEffect}
       fullWidth={fullWidth}
+      noPadding
     >
       <textarea
         ref={textAreaElRef}
-        className={cn({ resize }, resizeDirection)}
+        className={cn({ resize }, resizeDirection, 'JinniInputBasePadding')}
         value={textAreaValue}
         onChange={handleChange}
         disabled={disabled}


### PR DESCRIPTION
## 작업 내용 \*

### 변경 사항

1. InputBase에 `noPadding` prop 추가

   - noPadding: true이면, InputBaseContent에 padding이 적용되지 않음

2. InputBase 하위에서 'JinniInputBasePadding' 클래스명이 있는 요소에 size(sm, md, lg) 별로 padding을 적용할 수 있음

### 해결한 이슈

- `noPadding` prop과 'JinniInputBasePadding' 클래스명을 사용해 InputBase 내에서 padding 적용 요소를 조절할 수 있음
- 이로 인해 아래 이슈들을 해결함

1. Input 컴포넌트
   - InputBaseContent의 padding 부분을 클릭하면 input 요소에 포커스가 가지 않음
   - type을 ‘date’로 둔 후, date picker를 open 했을 때 date picker box의 위치가 Input 안에 걸쳐서 위치함
 
2. TextArea 컴포넌트
   - InputBaseContent의 padding 부분을 클릭하면 input 요소에 포커스가 가지 않음
   - resize=true 시 우측 하단에 있는 ‘//’ 표시가 안쪽으로 들어와 있음

3. Autocomplete 컴포넌트
   - InputBaseContent의 padding 부분을 클릭하면 input 요소에 포커스가 가지 않음
 
4. NumberInput 컴포넌트
   - InputBaseContent의 padding 부분을 클릭하면 input 요소에 포커스가 가지 않음
   - 입력값이 min/max 범위에 벗어난 상태에서 InputBaseContent의 padding 부분 클릭 시 focus out 이벤트가 발생했다고 생각해 clamp effect가 발생함

## 참고 자료
