### PR TITLE
🐛 Fix : Select - 포커스 후 엔터키 눌렀을 때, 첫번째 option이 선택되는 이슈 해결

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -119,7 +119,10 @@ const Select = <Multiple extends boolean = false, T extends AsType = 'div'>(
         )}
         onClick={openMenu}
         onKeyDown={(e: React.KeyboardEvent) => {
-          if (e.key === 'Enter') openMenu();
+          e.preventDefault();
+          if (e.key === 'Enter') {
+            openMenu();
+          }
         }}
         startAdornment={startAdornment}
         endAdornment={endAdornment}


### PR DESCRIPTION
## 작업 내용 \*

### 이슈
Select 컴포넌트가 값이 선택되지 않은 상태에서 포커스된 후 엔터키를 눌렀을 때 menu가 열리지도 않고 첫 번째 option이 선택됨

### 원인
Select 내부 InputBase에 아래 onKeyDown prop이 설정 되어 있어서 포커된 후 엔터키를 누르면 menu가 열림

```tsx
<InputBase
  tabIndex={0}
  onKeyDown={(e: React.KeyboardEvent) => {
    if (e.key === 'Enter') openMenu();
  }}
 ...
>
   ...
</InputBase>
```

menu가 열리는 즉시 첫 번째 option이 포커스 되는데, 이때 enter 키 이벤트가 여기에 적용되게 되고 첫 번째 option이 선택된 채 menu가 닫히게 됨
이 일련의 과정이 빠르게 일어나면서 사용자가 보기에는 마치 menu가 열리지도 않고 첫 번째 option이 선택된 것처럼 보였던 것임

### 해결

단순히 `e.preventDefault();`를 추가해 enter 키 이벤트의 기본 특징을 제거함

## 참고 자료
