### PR TITLE
✨ Feat : Autocomplete - Menu 대신 Popper로 MenuList를 띄움

### DIFF
--- a/src/components/Autocomplete/Autocomplete.hooks.ts
+++ b/src/components/Autocomplete/Autocomplete.hooks.ts
@@ -29,6 +29,7 @@ type UseBlurProps<Multiple extends boolean = false> = Required<
 > &
   Pick<AutocompleteProps<Multiple>, 'multiple'> & {
     inputElRef: React.RefObject<HTMLInputElement | null>;
+    inputBaseElRef: React.RefObject<HTMLDivElement | null>;
     menuListElRef: React.RefObject<HTMLUListElement | null>;
     autocompleteValue: OptionValueType[];
     valueToLabel: (value: OptionValueType) => string;
@@ -46,6 +47,8 @@ type UseAutocompleteValueLabel = Pick<AutocompleteProps, 'children'>;
 type UseKeyboardAccessibility = {
   inputElRef: React.RefObject<HTMLInputElement | null>;
   menuListElRef: React.RefObject<HTMLUListElement | null>;
+  isOpen: boolean;
+  closeMenu: (event: Event | React.SyntheticEvent) => void;
 };
 
 export const useAutocompleteValue = <Multiple extends boolean = false>({
@@ -211,6 +214,7 @@ export const useMenuOpen = ({
 
 export const useBlur = <Multiple extends boolean = false>({
   inputElRef,
+  inputBaseElRef,
   menuListElRef,
   mode,
   multiple,
@@ -227,10 +231,12 @@ export const useBlur = <Multiple extends boolean = false>({
 
     const handleBlur = (event: FocusEvent) => {
       const menuListEl = menuListElRef.current;
-      if (!menuListEl) return;
+      const inputBaseEl = inputBaseElRef.current;
+      if (!menuListEl || !inputBaseEl) return;
 
       const focusedEl = event.relatedTarget as Node;
-      const isBackgroundFocused = !menuListEl.contains(focusedEl);
+      const isBackgroundFocused =
+        !menuListEl.contains(focusedEl) && !inputBaseEl.contains(focusedEl);
 
       if (isBackgroundFocused && mode === 'strict') {
         closeMenu(event);
@@ -248,13 +254,29 @@ export const useBlur = <Multiple extends boolean = false>({
         }
       }
     };
+    const handleBackgroundClick = (event: MouseEvent) => {
+      const menuListEl = menuListElRef.current;
+      const inputBaseEl = inputBaseElRef.current;
+      if (!menuListEl || !inputBaseEl) return;
+
+      const clickedEl = event.target as Node;
+      const isBackgroundClicked =
+        !menuListEl.contains(clickedEl) && !inputBaseEl.contains(clickedEl);
+
+      if (isBackgroundClicked) {
+        closeMenu(event);
+      }
+    };
 
     inputEl.addEventListener('blur', handleBlur);
+    document.addEventListener('click', handleBackgroundClick);
     return () => {
       inputEl.removeEventListener('blur', handleBlur);
+      document.removeEventListener('click', handleBackgroundClick);
     };
   }, [
     inputElRef,
+    inputBaseElRef,
     menuListElRef,
     mode,
     multiple,
@@ -269,13 +291,15 @@ export const useBlur = <Multiple extends boolean = false>({
 
 export const useKeyboardAccessibility = ({
   inputElRef,
-  menuListElRef
+  menuListElRef,
+  isOpen,
+  closeMenu
 }: UseKeyboardAccessibility) => {
   useEffect(() => {
     const inputEl = inputElRef.current;
-    if (!inputEl) return;
+    if (!inputEl || !isOpen) return;
 
-    const handleKeyDown = (event: KeyboardEvent) => {
+    const handleArrowDown = (event: KeyboardEvent) => {
       const menuListEl = menuListElRef.current;
       if (!menuListEl) return;
 
@@ -284,12 +308,20 @@ export const useKeyboardAccessibility = ({
         menuListEl.focus();
       }
     };
-
-    inputEl.addEventListener('keydown', handleKeyDown);
-    return () => {
-      inputEl.addEventListener('keydown', handleKeyDown);
+    const handleEscapeAndTap = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' || e.key === 'Tab') {
+        closeMenu(e);
+        inputEl.focus();
+      }
     };
-  }, [inputElRef, menuListElRef]);
+
+    inputEl.addEventListener('keydown', handleArrowDown);
+    document.addEventListener('keydown', handleEscapeAndTap);
+    return () => {
+      inputEl.addEventListener('keydown', handleArrowDown);
+      document.removeEventListener('keydown', handleEscapeAndTap);
+    };
+  }, [inputElRef, menuListElRef, isOpen, closeMenu]);
 };
 
 export const useAutocompleteValueLabel = ({

--- a/src/components/Autocomplete/Autocomplete.mdx
+++ b/src/components/Autocomplete/Autocomplete.mdx
@@ -156,24 +156,25 @@ import AutocompleteOption from '@/components/AutocompleteOption';
 
 <Canvas of={AutocompleteStories.DisableEffects} />
 
-### Customize Menu
+### Customize Popper and MenuList
 
-- `Autocomplete` 컴포넌트는 내부적으로 `Menu` 컴포넌트를 반환하므로, `MenuProps`를 통해 `Menu`를 커스텀 가능
-- `MenuProps`: `Menu` 컴포넌트의 props
+- `Autocomplete` 컴포넌트는 내부적으로 `Popper`와 `MenuList` 컴포넌트를 반환하므로, `PopperProps`와 `MenuListProps`를 통해 `Popper`와 `MenuList`를 커스텀 가능
+- `PopperProps`: `Popper` 컴포넌트의 props
+- `MenuListProps`: `MenuList` 컴포넌트의 props
 
 #### 1. Dense
 
 <Canvas of={AutocompleteStories.Dense} />
 
-#### 2. Menu Position
+#### 2. Popper Position
 
-<Canvas of={AutocompleteStories.MenuPosition} />
+<Canvas of={AutocompleteStories.PopperPosition} />
 
 ## Props
 
 ### Autocomplete
 
-- `InputBase` 컴포넌트 + `Menu` 컴포넌트로 구성됨
+- `InputBase` + `Popper` + `MenuList` 컴포넌트로 구성됨
 
 <ArgTypes of={AutocompleteStories} sort="alpha" />
 

--- a/src/components/Autocomplete/Autocomplete.scss
+++ b/src/components/Autocomplete/Autocomplete.scss
@@ -108,7 +108,7 @@
   }
 }
 
-.JinniAutocompleteMenu {
+.JinniAutocompletePopper {
   margin-top: 1px;
   width: 300px;
 

--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -46,10 +46,10 @@ const meta: Meta<typeof Autocomplete> = {
         type: { summary: `string` }
       }
     },
-    MenuProps: {
-      description: 'Menu 컴포넌트의 props',
+    MenuListProps: {
+      description: 'MenuList 컴포넌트의 props',
       table: {
-        type: { summary: `MenuProps` }
+        type: { summary: `MenuListProps` }
       }
     },
     mode: {
@@ -109,6 +109,12 @@ const meta: Meta<typeof Autocomplete> = {
         type: {
           summary: `boolean`
         }
+      }
+    },
+    PopperProps: {
+      description: 'Popper 컴포넌트의 props',
+      table: {
+        type: { summary: `PopperProps` }
       }
     },
     placeholder: {
@@ -1103,7 +1109,7 @@ const LoadOnOpenTemplate = () => {
       open={open}
       onOpen={openMenu}
       onClose={closeMenu}
-      MenuProps={{ className: 'remove-no-option-item' }}
+      MenuListProps={{ className: 'remove-no-option-item' }}
     >
       {isLoading ? (
         <ListItem className="loading" style={{ color: 'on-surface-variant' }}>
@@ -1158,7 +1164,7 @@ const SearchAsTypeTemplate = () => {
     <Autocomplete
       inputValue={inputValue}
       onInputChange={handleInputChange}
-      MenuProps={{ className: 'remove-no-option-item' }}
+      MenuListProps={{ className: 'remove-no-option-item' }}
     >
       {isLoading ? (
         <Box
@@ -1925,7 +1931,7 @@ export const LoadOnOpen: Story = {
       open={open}
       onOpen={openMenu}
       onClose={closeMenu}
-      MenuProps={{ className: 'remove-no-option-item' }}
+      MenuListProps={{ className: 'remove-no-option-item' }}
     >
       {isLoading ? (
         <ListItem className="loading" style={{ color: 'on-surface-variant' }}>
@@ -1989,7 +1995,7 @@ export const SearchAsYourType: Story = {
     <Autocomplete
       inputValue={inputValue}
       onInputChange={handleInputChange}
-      MenuProps={{ className: 'remove-no-option-item' }}
+      MenuListProps={{ className: 'remove-no-option-item' }}
     >
       {isLoading ? (
         <Box
@@ -2147,7 +2153,7 @@ export const DisableEffects: Story = {
 
 export const Dense: Story = {
   render: (args) => (
-    <Autocomplete MenuProps={{ MenuListProps: { dense: true } }} {...args}>
+    <Autocomplete MenuListProps={{ dense: true }} {...args}>
       {OPTIONS.map(({ value, label }) => (
         <AutocompleteOption key={value} value={value} label={label}>
           {label}
@@ -2157,12 +2163,12 @@ export const Dense: Story = {
   )
 };
 
-export const MenuPosition: Story = {
+export const PopperPosition: Story = {
   render: (args) => (
     <Autocomplete
-      MenuProps={{
+      PopperProps={{
         anchorOrigin: { horizontal: 'right', vertical: 'bottom' },
-        menuOrigin: { horizontal: 'left', vertical: 'top' }
+        popperOrigin: { horizontal: 'left', vertical: 'top' }
       }}
       {...args}
     >

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -8,7 +8,8 @@ import InputBase, {
   InputBaseProps,
   RootInputBaseProps
 } from '@/components/InputBase';
-import Menu, { MenuProps } from '@/components/Menu';
+import MenuList, { MenuListProps } from '@/components/MenuList';
+import Popper, { PopperProps } from '@/components/Popper';
 import Chip from '@/components/Chip';
 import {
   useAutocompleteValue,
@@ -59,10 +60,11 @@ export type AutocompleteProps<Multiple extends boolean = false> = Omit<
         valueToDelete: OptionValueType
       ) => void
     ) => React.ReactNode;
-    MenuProps?: Omit<
-      MenuProps,
-      'open' | 'onClose' | 'anchorReference' | 'anchorElRef' | 'anchorPosition'
+    PopperProps?: Omit<
+      PopperProps,
+      'anchorReference' | 'anchorElRef' | 'anchorPosition'
     >;
+    MenuListProps?: MenuListProps;
     open?: boolean;
     onOpen?: (event: Event | React.SyntheticEvent) => void;
     onClose?: (event: Event | React.SyntheticEvent) => void;
@@ -126,7 +128,6 @@ const Autocomplete = <Multiple extends boolean = false>(
     onChange,
     onInputChange,
     renderValue = multiple ? DefaultRenderValue : undefined,
-    MenuProps,
     startAdornment,
     endAdornment,
     variant,
@@ -142,6 +143,8 @@ const Autocomplete = <Multiple extends boolean = false>(
     open,
     onOpen,
     onClose,
+    MenuListProps,
+    PopperProps,
     className,
     style,
     ...rest
@@ -179,6 +182,7 @@ const Autocomplete = <Multiple extends boolean = false>(
   });
   useBlur({
     inputElRef,
+    inputBaseElRef,
     menuListElRef,
     mode,
     multiple,
@@ -191,13 +195,11 @@ const Autocomplete = <Multiple extends boolean = false>(
   });
   useKeyboardAccessibility({
     inputElRef,
-    menuListElRef
+    menuListElRef,
+    isOpen,
+    closeMenu
   });
-  const {
-    className: menuClassName,
-    MenuListProps: menuListProps,
-    ...restMenuProps
-  } = MenuProps || {};
+  const { className: popperClassName, ...restPopperProps } = PopperProps || {};
 
   const handleEnterKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
@@ -243,7 +245,7 @@ const Autocomplete = <Multiple extends boolean = false>(
               onClick={(event: React.MouseEvent) => {
                 toggleMenu(event);
                 setIsFiltered(false);
-                inputElRef.current?.focus();
+                if (!isOpen) inputElRef.current?.focus();
               }}
             >
               <ArrowDownIcon color="on-surface-variant" size={16} />
@@ -302,6 +304,7 @@ const Autocomplete = <Multiple extends boolean = false>(
           onClick={(event: React.MouseEvent) => {
             initInputValue(event);
             initAutocompleteValue(event);
+            inputElRef.current?.focus();
           }}
           tabIndex={-1}
         >
@@ -316,25 +319,25 @@ const Autocomplete = <Multiple extends boolean = false>(
           tabIndex={-1}
         />
       </InputBase>
-      <Menu
-        className={cn('JinniAutocompleteMenu', menuClassName)}
-        anchorReference="anchorEl"
-        anchorElRef={inputBaseElRef}
-        open={isOpen}
-        onClose={(event: MouseEvent | KeyboardEvent) => closeMenu(event)}
-        disableMenuListFocused
-        MenuListProps={{
-          role: 'listbox',
-          id: menuListId,
-          ref: menuListElRef,
-          disableAlphabetKeyFocus: true,
-          ...menuListProps
-        }}
-        {...restMenuProps}
-      >
-        {children}
-        <ListItem className="no-options">No Options</ListItem>
-      </Menu>
+      {isOpen && (
+        <Popper
+          className={cn('JinniAutocompletePopper', popperClassName)}
+          anchorReference="anchorEl"
+          anchorElRef={inputBaseElRef}
+          {...restPopperProps}
+        >
+          <MenuList
+            ref={menuListElRef}
+            role="listbox"
+            id={menuListId}
+            disableAlphabetKeyFocus
+            {...MenuListProps}
+          >
+            {children}
+            <ListItem className="no-options">No Options</ListItem>
+          </MenuList>
+        </Popper>
+      )}
     </AutocompleteContext>
   );
 };

--- a/src/components/Autocomplete/CustomAutocomplete.scss
+++ b/src/components/Autocomplete/CustomAutocomplete.scss
@@ -1,5 +1,5 @@
-.remove-no-option-item.JinniAutocompleteMenu {
-  .loading + .JinniListItem.no-options {
+.remove-no-option-item.JinniMenuList {
+  .JinniListItem.loading + .JinniListItem.no-options {
     display: none;
   }
 }

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -119,8 +119,8 @@ const Select = <Multiple extends boolean = false, T extends AsType = 'div'>(
         )}
         onClick={openMenu}
         onKeyDown={(e: React.KeyboardEvent) => {
-          e.preventDefault();
           if (e.key === 'Enter') {
+            e.preventDefault();
             openMenu();
           }
         }}


### PR DESCRIPTION
## 작업 내용 \*

### 기존

- Autocomplete 내부에서 조건에 따라 Menu 컴포넌트를 띄움

### 문제점

- Menu가 오픈된 상태에서 입력란에 텍스트를 입력하면 우측에 close button이 나타남
- 이때, 입력란에 적힌 텍스트를 지우기 위해서 close button 위에 마우스를 두고 클릭하면,
사실상 위에 덮여있던 투명한 backdrop이 클릭되어 메뉴가 close 될 뿐
close button은 클릭되지 않았으므로 텍스트가 삭제되진 않음
- 메뉴가 close된 상태에서 close button을 한번 더 눌러야 텍스트가 삭제 됨

### 해결 방법

- 사실, Menu는 오픈 됐을 때 background와 상호작용을 막는 것이 기본 특징이므로, 
Autocomplete처럼 menu item과 상호작용 하면서 input에 값을 입력하려면 
Menu 컴포넌트가 아닌 background와 상호작용이 가능한 Popper를 사용하는 것이 맞음
- 따라서, Menu 대신 Popper로 MenuList를 띄워줌

### 변경 사항

- Autocomplete에서 `MenuProps` prop 제거, `PopperProps`와 `MenuListProps` prop 추가


## 참고 자료
