### PR TITLE
✨ Feat : ColorPicker 접근성 보완, 각종 이슈 해결

### DIFF
--- a/src/components/ColorBox/AlphaSlider/AlphaSlider.tsx
+++ b/src/components/ColorBox/AlphaSlider/AlphaSlider.tsx
@@ -1,24 +1,35 @@
 'use client';
 
 import './AlphaSlider.scss';
+import { useRef, useCallback, memo, useLayoutEffect } from 'react';
 import Mosaic from '@/components/Mosaic';
 import Slider, { SliderValueType } from '@/components/Slider';
 import { useColorBoxContext } from '../ColorBox.hooks';
 import { hsbObjToRgbObj } from '@/components/ColorPicker';
 
-const AlphaSlider = () => {
+const AlphaSlider = memo(() => {
   const { colorValue, changeColorValue } = useColorBoxContext();
+  const colorValueRef = useRef(colorValue);
+  const changeColorValueRef = useRef(changeColorValue);
   const rgbObj = hsbObjToRgbObj(colorValue);
   const { r, g, b, a = 1 } = rgbObj;
   const rgbCss = `rgb(${r},${g},${b})`;
   const rgbaCss = `rgba(${r},${g},${b},${a})`;
 
-  const handleAlphaChange = (
-    event: React.SyntheticEvent | Event,
-    newAlpha: SliderValueType
-  ) => {
-    changeColorValue(event, { ...colorValue, a: (newAlpha as number) / 100 });
-  };
+  useLayoutEffect(() => {
+    colorValueRef.current = colorValue;
+    changeColorValueRef.current = changeColorValue;
+  }, [colorValue, changeColorValue]);
+
+  const handleAlphaChange = useCallback(
+    (event: React.SyntheticEvent | Event, newAlpha: SliderValueType) => {
+      changeColorValueRef.current(event, {
+        ...colorValueRef.current,
+        a: (newAlpha as number) / 100
+      });
+    },
+    []
+  );
 
   return (
     <Mosaic className="JinniColorBoxAlphaSlider">
@@ -32,6 +43,8 @@ const AlphaSlider = () => {
       />
     </Mosaic>
   );
-};
+});
+
+AlphaSlider.displayName = 'AlphaSlider';
 
 export default AlphaSlider;

--- a/src/components/ColorBox/HueSlider/HueSlider.tsx
+++ b/src/components/ColorBox/HueSlider/HueSlider.tsx
@@ -1,19 +1,30 @@
 'use client';
 
 import './HueSlider.scss';
+import { useRef, useCallback, memo, useLayoutEffect } from 'react';
 import Mosaic from '@/components/Mosaic';
 import Slider, { SliderValueType } from '@/components/Slider';
 import { useColorBoxContext } from '../ColorBox.hooks';
 
-const HueSlider = () => {
+const HueSlider = memo(() => {
   const { colorValue, changeColorValue } = useColorBoxContext();
+  const colorValueRef = useRef(colorValue);
+  const changeColorValueRef = useRef(changeColorValue);
 
-  const handleHueChange = (
-    event: React.SyntheticEvent | Event,
-    newHue: SliderValueType
-  ) => {
-    changeColorValue(event, { ...colorValue, h: newHue as number });
-  };
+  useLayoutEffect(() => {
+    colorValueRef.current = colorValue;
+    changeColorValueRef.current = changeColorValue;
+  }, [colorValue, changeColorValue]);
+
+  const handleHueChange = useCallback(
+    (event: React.SyntheticEvent | Event, newHue: SliderValueType) => {
+      changeColorValueRef.current(event, {
+        ...colorValueRef.current,
+        h: newHue as number
+      });
+    },
+    []
+  );
 
   return (
     <Mosaic className="JinniColorBoxHueSlider">
@@ -27,6 +38,8 @@ const HueSlider = () => {
       />
     </Mosaic>
   );
-};
+});
+
+HueSlider.displayName = 'HueSlider';
 
 export default HueSlider;

--- a/src/components/ColorBox/mixins.scss
+++ b/src/components/ColorBox/mixins.scss
@@ -8,7 +8,8 @@
   &:not(.disabled)::after {
     background-color: transparent;
   }
-  &:focus-within {
+  &:focus-visible,
+  &:has(input:focus-visible) {
     outline: 2px solid var(--jinni-color-gray-800);
   }
 }

--- a/src/components/ColorBox/mixins.scss
+++ b/src/components/ColorBox/mixins.scss
@@ -5,6 +5,12 @@
   border-radius: 50%;
   box-shadow: var(--jinni-box-shadow-5);
   cursor: pointer;
+  &:not(.disabled)::after {
+    background-color: transparent;
+  }
+  &:focus-within {
+    outline: 2px solid var(--jinni-color-gray-800);
+  }
 }
 
 @mixin input-label-style {

--- a/src/components/ColorBox/mixins.scss
+++ b/src/components/ColorBox/mixins.scss
@@ -43,7 +43,7 @@
       }
     }
 
-    .JinniInputBaseContent {
+    .JinniInputBaseContent input {
       padding-left: 5px;
       padding-right: 0px;
     }

--- a/src/components/ColorField/ColorField.tsx
+++ b/src/components/ColorField/ColorField.tsx
@@ -3,8 +3,15 @@
 import './ColorField.scss';
 import cn from 'classnames';
 import InputBase, { InputBaseProps } from '@/components/InputBase';
-import { ColorValueType } from '../ColorPicker';
+import {
+  ColorValueType,
+  isRgbObject,
+  isHsbObject,
+  rgbObjToRgbCss,
+  hsbObjToHex
+} from '../ColorPicker';
 import ColorBlock from '@/components/ColorBlock';
+import { ColorType } from '@/types/color';
 
 export type ColorFieldProps = InputBaseProps & {
   value?: ColorValueType;
@@ -18,8 +25,22 @@ const ColorField = ({ ref, ...props }: ColorFieldProps) => {
     ...rest
   } = props;
 
+  let focusedColor: ColorType;
+  if (isRgbObject(value)) {
+    focusedColor = rgbObjToRgbCss(value);
+  } else if (isHsbObject(value)) {
+    focusedColor = hsbObjToHex(value);
+  } else {
+    focusedColor = value;
+  }
+
   return (
-    <InputBase ref={ref} className={cn('JinniColorField', className)} {...rest}>
+    <InputBase
+      ref={ref}
+      className={cn('JinniColorField', className)}
+      focusedColor={focusedColor}
+      {...rest}
+    >
       {children}
     </InputBase>
   );

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import './ColorPicker.scss';
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import cn from 'classnames';
 import { AsType, DefaultComponentProps } from '@/types/default-component-props';
 import useStyle from '@/hooks/useStyle';
 import ColorField, { ColorFieldProps } from '../ColorField';
 import ColorBox, { ColorBoxProps } from '../ColorBox';
-import Popover, { PopoverProps, CloseReason } from '@/components/Popover';
+import Popover, { PopoverProps } from '@/components/Popover';
 import { useColorValue } from './ColorPicker.hooks';
 import { ColorValueType, HSBObject } from './ColorPicker.types';
 import { useLabelContext } from '@/components/Label';
@@ -28,7 +28,7 @@ export type ColorPickerProps<T extends AsType = 'div'> = Omit<
   required?: boolean;
   PopoverProps?: Omit<
     PopoverProps,
-    'open' | 'anchorReference' | 'anchorElRef' | 'anchorPosition'
+    'open' | 'onClose' | 'anchorReference' | 'anchorElRef' | 'anchorPosition'
   >;
 };
 
@@ -64,7 +64,6 @@ const ColorPicker = <T extends AsType = 'div'>(props: ColorPickerProps<T>) => {
   });
   const newStyle = useStyle(style);
   const {
-    onClose: popoverOnClose,
     BoxProps: popoverBoxProps,
     style: popoverStyle,
     ...restPopoverProps
@@ -77,13 +76,9 @@ const ColorPicker = <T extends AsType = 'div'>(props: ColorPickerProps<T>) => {
   const closePopover = () => {
     setOpen(false);
   };
-  const handlePopoverClose = (
-    event: MouseEvent | KeyboardEvent,
-    reason: CloseReason
-  ) => {
+  const handlePopoverClose = useCallback(() => {
     closePopover();
-    popoverOnClose?.(event, reason);
-  };
+  }, []);
 
   return (
     <Component

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -105,9 +105,12 @@ const ColorPicker = <T extends AsType = 'div'>(props: ColorPickerProps<T>) => {
       />
       {renderColorField({
         ref: anchorElRef,
+        tabIndex: 0,
         onClick: openPopover,
+        onKeyDown: (e) => e.key === 'Enter' && openPopover(),
         value: colorValue,
-        disabled
+        disabled,
+        focused: open
       })}
       <Popover
         anchorReference="anchorEl"

--- a/src/components/InputBase/InputBase.scss
+++ b/src/components/InputBase/InputBase.scss
@@ -29,8 +29,10 @@
 }
 
 @mixin focus-effect {
+  &:not(.disableFocusEffect):focus,
   &:not(.disableFocusEffect):focus-within,
   &:not(.disableFocusEffect).focused {
+    outline: none;
     &.outlined {
       border-color: var(--focused-color);
       box-shadow: var(--focused-color) 0 0 0 1px;

--- a/src/components/Menu/Menu.scss
+++ b/src/components/Menu/Menu.scss
@@ -1,3 +1,7 @@
 .JinniMenu {
   transform-origin: var(--transform-origin);
 }
+
+.JinniMenuBackdrop.JinniBackdrop {
+  z-index: var(--jinni-z-index-popper);
+}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -84,6 +84,7 @@ const Menu = <T extends AsType = 'div'>(props: MenuProps<T>) => {
       {open && (
         <>
           <Backdrop
+            className="JinniMenuBackdrop"
             invisible
             disableScroll={disableScroll}
             onClick={handleBackdropClick}

--- a/src/components/Popover/Popover.hooks.ts
+++ b/src/components/Popover/Popover.hooks.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { PopoverProps } from './Popover';
+import { findFocusableSelectors } from './Popover.utils';
 
 export const useKeyboardAccessibility = ({
   open,
@@ -7,6 +8,11 @@ export const useKeyboardAccessibility = ({
   anchorElRef
 }: Pick<PopoverProps, 'open' | 'onClose' | 'anchorElRef'>) => {
   const boxElRef = useRef<HTMLDivElement>(null);
+  const focusableElRef = useRef<{
+    focusableEls: HTMLElement[];
+    firstEl?: HTMLElement;
+    lastEl?: HTMLElement;
+  }>({ focusableEls: [] });
 
   useEffect(() => {
     if (!open) return;
@@ -15,22 +21,9 @@ export const useKeyboardAccessibility = ({
     const boxEl = boxElRef.current;
     if (!boxEl) return;
 
-    const focusableSelectors = [
-      'a[href]',
-      'button:not([disabled])',
-      'textarea:not([disabled])',
-      'input:not([disabled])',
-      'select:not([disabled])',
-      '[tabindex]:not([tabindex="-1"])'
-    ];
-    const focusableEls = Array.from(
-      boxEl.querySelectorAll<HTMLElement>(focusableSelectors.join(','))
-    );
-    const firstEl = focusableEls[0];
-    const lastEl = focusableEls[focusableEls.length - 1];
-
+    focusableElRef.current = findFocusableSelectors(boxEl);
     if (!boxEl.contains(document.activeElement)) {
-      (firstEl || boxEl).focus();
+      (focusableElRef.current.firstEl || boxEl).focus();
     }
 
     const handleKeydown = (e: KeyboardEvent) => {
@@ -38,17 +31,18 @@ export const useKeyboardAccessibility = ({
         onClose?.(e, 'escapeKeyDown');
       }
       if (e.key === 'Tab') {
+        const { focusableEls, firstEl, lastEl } = focusableElRef.current;
         if (focusableEls.length === 0) {
           e.preventDefault();
           return;
         }
         if (e.shiftKey) {
-          if (document.activeElement === firstEl) {
+          if (lastEl && document.activeElement === firstEl) {
             e.preventDefault();
             lastEl.focus();
           }
         } else {
-          if (document.activeElement === lastEl) {
+          if (firstEl && document.activeElement === lastEl) {
             e.preventDefault();
             firstEl.focus();
           }
@@ -57,8 +51,17 @@ export const useKeyboardAccessibility = ({
     };
 
     document.addEventListener('keydown', handleKeydown);
+    const observer = new MutationObserver(() => {
+      focusableElRef.current = findFocusableSelectors(boxEl);
+    });
+    observer.observe(boxEl, {
+      attributes: true,
+      childList: true,
+      subtree: true
+    });
     return () => {
       document.removeEventListener('keydown', handleKeydown);
+      observer.disconnect();
       anchorEl?.focus();
     };
   }, [open, onClose, anchorElRef]);

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -10,3 +10,7 @@
     }
   }
 }
+
+.JinniPopoverBackdrop.JinniBackdrop {
+  z-index: var(--jinni-z-index-popper);
+}

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -77,6 +77,7 @@ const Popover = <T extends AsType = 'div'>(props: PopoverProps<T>) => {
       {open && (
         <>
           <Backdrop
+            className="JinniPopoverBackdrop"
             invisible
             disableScroll={disableScroll}
             onClick={handleBackdropClick}

--- a/src/components/Popover/Popover.utils.ts
+++ b/src/components/Popover/Popover.utils.ts
@@ -1,0 +1,17 @@
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])'
+];
+
+export const findFocusableSelectors = (targetEl: HTMLElement) => {
+  const focusableEls = Array.from(
+    targetEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS.join(','))
+  );
+  const firstEl = focusableEls[0];
+  const lastEl = focusableEls[focusableEls.length - 1];
+  return { focusableEls, firstEl, lastEl };
+};


### PR DESCRIPTION
## 작업 내용 \*

### 디자인 수정
- ColorBox 내 NumberInput 패딩 처리 수정
- Palette, AlphaSlider, HueSlider - thumb 포커스 여부를 분명히 알 수 있도록 수정

### 키보드 접근성 보완
- ColorField에 포커스 가능하게 하고, 포커스된 채 enter 키를 누르면 color box를 오픈할 수 있게 함

### 이슈 해결

#### 1. AlphaSlider, HueSlider - 포커스 후 방향키 누를 때 버벅거리는 이슈

- 원인: 방향키로 thumb 이동 → 
Slider의 value 값 뿐만 아니라 onChange prop으로 들어오는 handler도 변경됨 →
onChange 값이 변경됨에 따라 이를 의존성 배열에 넣어둔 useCallback, useEffect가 불필요하게 다시 실행됨 → 
이 과정이 짧은 시간에 반복해서 일어나면서 버벅거림이 발생함
- 해결: handler를 useCallback으로 감싸 리렌더링 시 새로 생성하지 않도록 함

#### 2. FormatSelect - open 후 option 선택 없이 color box 클릭 시 close 되지 않는 이슈

- 원인: FormatSelect의 backdrop이 Popover로 띄운 color box보다 z-index가 낮기 때문에 color box 뒤에 위치하게 됨
- 해결: Menu의 backdrop을 popper의 z-index와 동일하게 맞춰주어 open된 순서에 따라 z축 방향으로 순서대로 위에 쌓이게 함

#### 3. FormatSelect에서 새 option 선택 시 focus trap이 깨지는 이슈

- 원인: format 옵션을 변경한 후 focusableEls를 재계산하지 않기 때문에, 기존 lastEl가 변경된 후의 실제 lastEl와 같지 않아 조건문을 만족하지 못해 focus trap을 벗어나게 됨
- 해결: MutationObserver를 사용해 Popover 내 콘텐츠가 변경될 때마다 focusableEls를 재계산 함

## 참고 자료
