### PR TITLE
🐛 Fix : DateTimeField - '오후' 글자 짤려 보이는 이슈 해결

### DIFF
--- a/src/components/AutoWidthInput/AutoWidthInput.tsx
+++ b/src/components/AutoWidthInput/AutoWidthInput.tsx
@@ -40,12 +40,13 @@ const AutoWidthInput = ({ ref, ...props }: AutoWidthInputProps) => {
       />
       <span
         ref={hiddenElRef}
+        className={className}
         style={{
           position: 'absolute',
           visibility: 'hidden',
-          height: 0,
-          overflow: 'hidden',
-          font: 'inherit'
+          pointerEvents: 'none',
+          font: 'inherit',
+          whiteSpace: 'nowrap'
         }}
       >
         {value || ' '}

--- a/src/components/DateField/DateField.hooks.ts
+++ b/src/components/DateField/DateField.hooks.ts
@@ -56,7 +56,7 @@ type UseInputProps = {
   dateObjectToDate: ({ year, month, day }: DateObjectType) => Date;
 };
 
-type UseFocusProps = {
+type UseFocusProps = Pick<DateFieldProps, 'onArrowRightFromLastPart'> & {
   datePartsElRef: React.RefObject<HTMLElement[]>;
 };
 
@@ -283,7 +283,10 @@ export const useDateFormat = ({
   };
 };
 
-export const useFocus = ({ datePartsElRef }: UseFocusProps) => {
+export const useFocus = ({
+  datePartsElRef,
+  onArrowRightFromLastPart
+}: UseFocusProps) => {
   const focusPrevDatePart = useCallback(
     (currentDatePartEl: HTMLElement): boolean => {
       const currentIndex = datePartsElRef.current.indexOf(currentDatePartEl);
@@ -307,9 +310,10 @@ export const useFocus = ({ datePartsElRef }: UseFocusProps) => {
         nextDatePartEl.focus();
         return true;
       }
+      onArrowRightFromLastPart?.();
       return false;
     },
-    [datePartsElRef]
+    [datePartsElRef, onArrowRightFromLastPart]
   );
 
   const focusNextDatePartOrBlur = (currentDatePartEl: HTMLElement) => {

--- a/src/components/DateField/DateField.stories.tsx
+++ b/src/components/DateField/DateField.stories.tsx
@@ -52,6 +52,15 @@ const meta: Meta<typeof DateField> = {
         type: { summary: 'string' }
       }
     },
+    onArrowRightFromLastPart: {
+      description:
+        '마지막 date part가 포커스된 상태에서 ArrowRight 방향키가 눌렸을 때 호출되는 함수',
+      table: {
+        type: {
+          summary: `() => void;`
+        }
+      }
+    },
     onChange: {
       description: 'value가 변경됐을 때 호출되는 함수',
       table: {

--- a/src/components/DateField/DateField.tsx
+++ b/src/components/DateField/DateField.tsx
@@ -31,6 +31,7 @@ export type DateFieldProps<T extends AsType = 'div'> = Omit<
     format?: string;
     onErrorStatus?: (error: boolean, errorReason?: DateValidationError) => void;
     disabledDates?: Array<Date> | DisabledDatesFnType;
+    onArrowRightFromLastPart?: () => void;
   };
 
 const DateField = <T extends AsType = 'div'>({
@@ -49,6 +50,7 @@ const DateField = <T extends AsType = 'div'>({
     placeholder,
     format,
     onErrorStatus,
+    onArrowRightFromLastPart,
     color,
     focusedColor,
     onClick,
@@ -85,7 +87,10 @@ const DateField = <T extends AsType = 'div'>({
     onErrorStatus,
     dateObjectToDate
   });
-  const { focusNextDatePartOrBlur } = useFocus({ datePartsElRef });
+  const { focusNextDatePartOrBlur } = useFocus({
+    datePartsElRef,
+    onArrowRightFromLastPart
+  });
   const { handleInputChange } = useInput({
     dateValue,
     yearDigit,

--- a/src/components/DateTimeField/DateTimeField.hooks.ts
+++ b/src/components/DateTimeField/DateTimeField.hooks.ts
@@ -1,4 +1,11 @@
-import { useState, useCallback, useLayoutEffect, useMemo, useRef } from 'react';
+import {
+  useState,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useEffect
+} from 'react';
 import { DateTimeFieldProps } from './DateTimeField';
 import { TimeValidationError } from '@/types/time-component';
 import { DateTimeValidationError } from '@/types/date-time-component';
@@ -124,5 +131,54 @@ export const useValidation = ({
   return {
     isValidationError,
     onTimeFieldErrorStatus
+  };
+};
+
+export const useFocus = () => {
+  const dateFieldElRef = useRef<HTMLDivElement>(null);
+  const timeFieldElRef = useRef<HTMLDivElement>(null);
+
+  const focusFirstPartInTimeField = useCallback(() => {
+    const timeFieldEl = timeFieldElRef.current;
+    if (!timeFieldEl) return;
+
+    const timeInputParts = timeFieldEl.querySelectorAll<HTMLElement>(
+      '.JinniAutoWidthInput.JinniTimeFieldTimePart'
+    );
+    const firstPart = timeInputParts[0];
+    if (firstPart) {
+      firstPart.focus();
+    }
+  }, []);
+
+  const focusLastPartInDateField = useCallback(() => {
+    const dateFieldEl = dateFieldElRef.current;
+    if (!dateFieldEl) return;
+
+    const dateInputParts = dateFieldEl.querySelectorAll<HTMLElement>(
+      '.JinniAutoWidthInput.JinniDateFieldDatePart'
+    );
+    const lastPart = dateInputParts[dateInputParts.length - 1];
+    if (lastPart) {
+      lastPart.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    const timeFieldEl = timeFieldElRef.current;
+    if (!timeFieldEl) return;
+    const timeInputParts = timeFieldEl.querySelectorAll<HTMLElement>(
+      '.JinniAutoWidthInput.JinniTimeFieldTimePart'
+    );
+    timeInputParts.forEach((timeInput) => {
+      timeInput.tabIndex = -1;
+    });
+  }, []);
+
+  return {
+    dateFieldElRef,
+    timeFieldElRef,
+    focusFirstPartInTimeField,
+    focusLastPartInDateField
   };
 };

--- a/src/components/DateTimeField/DateTimeField.tsx
+++ b/src/components/DateTimeField/DateTimeField.tsx
@@ -6,7 +6,11 @@ import cn from 'classnames';
 import InputBase, { InputBaseProps } from '@/components/InputBase';
 import DateField from '@/components/DateField';
 import TimeField from '@/components/TimeField';
-import { useDateTimeValue, useValidation } from './DateTimeField.hooks';
+import {
+  useDateTimeValue,
+  useFocus,
+  useValidation
+} from './DateTimeField.hooks';
 import { TimeMode } from '@/types/time-component';
 import {
   DateTimeComponentProps,
@@ -68,6 +72,12 @@ const DateTimeField = <Mode extends TimeMode = 'preset'>({
     disabledDateTimes,
     onErrorStatus
   });
+  const {
+    dateFieldElRef,
+    timeFieldElRef,
+    focusFirstPartInTimeField,
+    focusLastPartInDateField
+  } = useFocus();
   const noValue = dateTimeValue === null;
 
   const commonProps = {
@@ -80,18 +90,22 @@ const DateTimeField = <Mode extends TimeMode = 'preset'>({
   };
   const dateFieldProps = {
     ...commonProps,
+    ref: dateFieldElRef,
     onChange: handleDateChange,
     options: filterDateOptions(options),
-    format: dateFormat
+    format: dateFormat,
+    onArrowRightFromLastPart: focusFirstPartInTimeField
   };
   const timeFieldProps = {
     ...commonProps,
+    ref: timeFieldElRef,
     onChange: handleTimeChange,
     options: filterTimeOptions(options),
     mode: timeMode,
     timeStep,
     format: timeFormat,
-    onErrorStatus: onTimeFieldErrorStatus
+    onErrorStatus: onTimeFieldErrorStatus,
+    onArrowLeftFromFirstPart: focusLastPartInDateField
   };
 
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {

--- a/src/components/TimeField/TimeField.hooks.ts
+++ b/src/components/TimeField/TimeField.hooks.ts
@@ -61,7 +61,7 @@ type UseValidationProps<Mode extends TimeMode = 'preset'> = Pick<
   timeObjectToDate: TimeObjectToDate;
 };
 
-type UseFocusProps = {
+type UseFocusProps = Pick<TimeFieldProps, 'onArrowLeftFromFirstPart'> & {
   timePartsElRef: React.RefObject<HTMLElement[]>;
 };
 
@@ -344,7 +344,10 @@ export const useTimeFormat = ({
   };
 };
 
-export const useFocus = ({ timePartsElRef }: UseFocusProps) => {
+export const useFocus = ({
+  timePartsElRef,
+  onArrowLeftFromFirstPart
+}: UseFocusProps) => {
   const focusPrevTimePart = useCallback(
     (currentTimePartEl: HTMLElement): boolean => {
       const currentIndex = timePartsElRef.current.indexOf(currentTimePartEl);
@@ -354,9 +357,10 @@ export const useFocus = ({ timePartsElRef }: UseFocusProps) => {
         prevTimePartEl.focus();
         return true;
       }
+      onArrowLeftFromFirstPart?.();
       return false;
     },
-    [timePartsElRef]
+    [timePartsElRef, onArrowLeftFromFirstPart]
   );
 
   const focusNextTimePart = useCallback(

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -56,6 +56,15 @@ const meta: Meta<typeof TimeField> = {
         defaultValue: { summary: `'preset'` }
       }
     },
+    onArrowLeftFromFirstPart: {
+      description:
+        '첫 번째 time part가 포커스된 상태에서 ArrowLeft 방향키가 눌렸을 때 호출되는 함수',
+      table: {
+        type: {
+          summary: `() => void;`
+        }
+      }
+    },
     onChange: {
       description: 'value가 변경됐을 때 호출되는 함수',
       table: {

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -38,6 +38,7 @@ export type TimeFieldProps<
     format?: string;
     disabledTimes?: Array<Date> | DisabledTimesFnType;
     onErrorStatus?: (error: boolean, errorReason?: TimeValidationError) => void;
+    onArrowLeftFromFirstPart?: () => void;
   };
 
 const TimeField = <T extends AsType = 'div', Mode extends TimeMode = 'preset'>({
@@ -60,6 +61,7 @@ const TimeField = <T extends AsType = 'div', Mode extends TimeMode = 'preset'>({
     placeholder,
     format,
     onErrorStatus,
+    onArrowLeftFromFirstPart,
     color,
     focusedColor,
     className,
@@ -96,7 +98,10 @@ const TimeField = <T extends AsType = 'div', Mode extends TimeMode = 'preset'>({
     onErrorStatus,
     timeObjectToDate
   });
-  const { focusNextTimePartOrBlur } = useFocus({ timePartsElRef });
+  const { focusNextTimePartOrBlur } = useFocus({
+    timePartsElRef,
+    onArrowLeftFromFirstPart
+  });
   const { handleInputChange } = useInput({
     localeHourValues,
     localeSecondValues,


### PR DESCRIPTION
## 작업 내용 \*

1. DateTimeField 이슈 해결
   - 이슈: 마운트 시기에 value를 렌더하는 경우, ‘오후’ 글자가 짤려 보임
   - 원인: AutoWidthInput 컴포넌트의 hidden span에 `height: 0`이 설정되어 있어서 텍스트 렌더링에 문제가 생김
   - 해결: `height: 0` 제거하고 대신 `pointerEvents: none`을 추가

2. DateTimeField 키보드 접근성 보완
   - DateTimeField 내에서 좌우 방향키를 통해 DateField와 TimeField 간 초점 이동이 가능하도록 함
   - DateField 컴포넌트에 `onArrowRightFromLastPart` prop 추가
   - TimeField 컴포넌트에 `onArrowLeftFromFirstPart` prop 추가

## 참고 자료
